### PR TITLE
chore: Ignore formatting of autogenerated files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
     - .gitattributes
     - .gitignore
     - .prettierignore
+    - LICENSE.md
     - README.md
     - nodemon.json
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,7 @@ on:
     - .gitattributes
     - .gitignore
     - .prettierignore
+    - LICENSE.md
     - README.md
     - nodemon.json
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 *.yaml
+/.github/release-please-manifest.json
+CHANGELOG.md
 dist/
 node_modules/


### PR DESCRIPTION
These files are generated by tools in the repository and will not be formatted according to standards, these should be ignored during CI to avoid disrupting the build and release process.