### PR TITLE
feat: Automatically remove expired credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,30 @@
 [Google Chrome] extension that intercepts the SAML assertion when logging into
 the [AWS] console and exchanges it for temporary [STS] credentials.
 
+## Getting started
+
+### Installation
+
+### Development and testing
+
+#### Requirements
+
+- [Google Chrome]
+- [Node.js] 20 and [npm] 9+
+
+Clone the repository and navigate to the `chrome-ext-aws-saml-sts` directory,
+and install dependencies with [npm].
+
+```bash
+git clone git@github.com:unfunco/chrome-ext-aws-saml-sts.git
+cd chrome-ext-aws-saml-sts
+npm install
+```
+
+```bash
+npm run dev
+```
+
 ## License
 
 © 2023 [Daniel Morris]\
@@ -12,4 +36,6 @@ Made available under the terms of the [Apache License 2.0].
 [aws]: https://aws.amazon.com
 [daniel morris]: https://unfun.co
 [google chrome]: https://www.google.com/chrome
+[node.js]: https://nodejs.org
+[npm]: https://www.npmjs.com
 [sts]: https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html

--- a/src/bg/event.ts
+++ b/src/bg/event.ts
@@ -88,6 +88,7 @@ export const onBeforeRequestEvent = (
             AWS_ACCESS_KEY_ID: data.Credentials.AccessKeyId!,
             AWS_SECRET_ACCESS_KEY: data.Credentials.SecretAccessKey!,
             AWS_SESSION_TOKEN: data.Credentials.SessionToken!,
+            __expires_at: Date.parse(data.Credentials.Expiration!.toString()),
           }).then(
             (): void => console.debug('Credentials saved.'),
             console.error,

--- a/src/bg/gc.ts
+++ b/src/bg/gc.ts
@@ -1,0 +1,16 @@
+import Browser from 'webextension-polyfill'
+import { AWSCredentials } from '@/utilities'
+
+const DEFAULT_GC_INTERVAL = 30_000
+
+export const gc = async (ms?: number): Promise<NodeJS.Timeout> => {
+  const credentials = (await Browser.storage.local.get(
+    'credentials',
+  )) as AWSCredentials
+
+  if (credentials.__expires_at < Date.now()) {
+    await Browser.storage.local.remove('credentials')
+  }
+
+  return setTimeout(gc, ms ?? DEFAULT_GC_INTERVAL)
+}

--- a/src/bg/index.ts
+++ b/src/bg/index.ts
@@ -1,5 +1,6 @@
 import Browser from 'webextension-polyfill'
 import { onBeforeRequestEvent } from '@/bg/event'
+import { gc } from '@/bg/gc'
 
 const AWS_SIGNIN_URL_SAML = 'https://signin.aws.amazon.com/saml'
 
@@ -12,3 +13,8 @@ Browser.webRequest.onBeforeRequest.addListener(
   { urls: [AWS_SIGNIN_URL_SAML] },
   ['requestBody'],
 )
+
+// Run garbage collection every 30 seconds to remove expired credentials
+// from local storage.
+// noinspection JSIgnoredPromiseFromCall
+gc(30_000)

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -23,6 +23,7 @@ const Popup = (): React.ReactElement => {
     AWS_ACCESS_KEY_ID: '',
     AWS_SECRET_ACCESS_KEY: '',
     AWS_SESSION_TOKEN: '',
+    __expires_at: 0,
   })
 
   const [platforms, setPlatforms] = useState<Platform[]>([

--- a/src/utilities/snippets.ts
+++ b/src/utilities/snippets.ts
@@ -2,6 +2,7 @@ export type AWSCredentials = {
   AWS_ACCESS_KEY_ID: string
   AWS_SECRET_ACCESS_KEY: string
   AWS_SESSION_TOKEN: string
+  __expires_at: number
 }
 
 export const iniSnippet = (credentials: AWSCredentials): string =>


### PR DESCRIPTION
The setTimeout function now gets called periodically, this provides a benefit of keeping the service worker alive, as well as providing the opportunity to remove expired credentials from local storage.