### PR TITLE
fix: Fix dark mode hover states

### DIFF
--- a/__tests__/components/__snapshots__/Popup.test.tsx.snap
+++ b/__tests__/components/__snapshots__/Popup.test.tsx.snap
@@ -9,21 +9,21 @@ exports[`Popup platform is configured to display macOS and Linux by default 1`] 
     className="mb-2 flex space-x-4"
   >
     <a
-      className="bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100 rounded-md px-3 py-2 text-sm font-medium"
+      className="bg-gray-200 text-gray-900 dark:bg-gray-800 dark:text-gray-100 rounded-md px-3 py-2 text-sm font-medium"
       href="#"
       onClick={[Function]}
     >
       macOS and Linux
     </a>
     <a
-      className="text-gray-500 hover:bg-gray-800 hover:text-gray-300 rounded-md px-3 py-2 text-sm font-medium"
+      className="text-gray-500 hover:bg-gray-200 hover:text-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200 rounded-md px-3 py-2 text-sm font-medium"
       href="#"
       onClick={[Function]}
     >
       Windows
     </a>
     <a
-      className="text-gray-500 hover:bg-gray-800 hover:text-gray-300 rounded-md px-3 py-2 text-sm font-medium"
+      className="text-gray-500 hover:bg-gray-200 hover:text-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200 rounded-md px-3 py-2 text-sm font-medium"
       href="#"
       onClick={[Function]}
     >

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -69,8 +69,8 @@ const Popup = (): React.ReactElement => {
           <a
             className={classNames(
               platform.current
-                ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
-                : 'text-gray-500 hover:bg-gray-800 hover:text-gray-300',
+                ? 'bg-gray-200 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                : 'text-gray-500 hover:bg-gray-200 hover:text-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200',
               'rounded-md px-3 py-2 text-sm font-medium',
             )}
             href={`#`}


### PR DESCRIPTION
In dark mode, the hover states of the navigation did not appear correctly.