### PR TITLE
chore: Format YAML with prettier-plugin-yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     prefix-development: chore
   cooldown:
     default-days: 7
-  directory: "/"
+  directory: '/'
   labels:
   - chore 🧹
   - workflows 👷‍♀️
@@ -24,7 +24,7 @@ updates:
     prefix-development: chore
   cooldown:
     default-days: 7
-  directory: "/"
+  directory: '/'
   labels:
   - chore 🧹
   pull-request-branch-name:

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,3 +1,3 @@
-"workflows 👷‍♀️":
+'workflows 👷‍♀️':
 - changed-files:
   - any-glob-to-any-file: .github/**/*.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-*.yaml
 /.github/release-please-manifest.json
 CHANGELOG.md
 dist/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,10 +6,18 @@
   "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
   "jsxSingleQuote": false,
+  "plugins": [
+    "@ianvs/prettier-plugin-sort-imports",
+    "@unfunco/prettier-plugin-yaml"
+  ],
   "printWidth": 80,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+  "yamlFlowCollectionSpacing": true,
+  "yamlIndentSequenceValues": false
 }

--- a/__tests__/bg/event.test.ts
+++ b/__tests__/bg/event.test.ts
@@ -1,7 +1,7 @@
-import type { WebRequest } from 'webextension-polyfill'
 import { handleBeforeRequestEvent } from '@/bg/event'
 import { assumeRoleWithSAML } from '@/bg/sts'
 import { saveCredentials } from '@/utilities/storage'
+import type { WebRequest } from 'webextension-polyfill'
 
 jest.mock('@/bg/sts', () => ({
   assumeRoleWithSAML: jest.fn(),

--- a/__tests__/bg/gc.test.ts
+++ b/__tests__/bg/gc.test.ts
@@ -1,8 +1,8 @@
-import Browser from 'webextension-polyfill'
 import {
   removeExpiredCredentials,
   startCredentialGarbageCollector,
 } from '@/bg/gc'
+import Browser from 'webextension-polyfill'
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve()

--- a/__tests__/components/Popup.test.tsx
+++ b/__tests__/components/Popup.test.tsx
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 
-import * as React from 'react'
 import Popup from '@/components/Popup'
-import Browser from 'webextension-polyfill'
+import * as React from 'react'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import Browser from 'webextension-polyfill'
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 

--- a/__tests__/utilities/aws-sdk-xml-builder.test.ts
+++ b/__tests__/utilities/aws-sdk-xml-builder.test.ts
@@ -1,3 +1,5 @@
+import { parseXML } from '@/utilities/aws-sdk-xml-builder'
+
 jest.mock('@aws-sdk/xml-builder/dist-es/XmlNode.js', () => ({
   XmlNode: class XmlNode {},
 }))
@@ -5,8 +7,6 @@ jest.mock('@aws-sdk/xml-builder/dist-es/XmlNode.js', () => ({
 jest.mock('@aws-sdk/xml-builder/dist-es/XmlText.js', () => ({
   XmlText: class XmlText {},
 }))
-
-import { parseXML } from '@/utilities/aws-sdk-xml-builder'
 
 describe('AWS SDK XML builder shim', (): void => {
   it('parses AWS STS XML without DOMParser', (): void => {

--- a/__tests__/utilities/snippets.test.ts
+++ b/__tests__/utilities/snippets.test.ts
@@ -1,9 +1,9 @@
 import {
-  type AWSCredentials,
   iniSnippet,
   powershellSnippet,
   unixSnippet,
   windowsSnippet,
+  type AWSCredentials,
 } from '@/utilities'
 
 describe('Utilities', (): void => {

--- a/__tests__/utilities/storage.test.ts
+++ b/__tests__/utilities/storage.test.ts
@@ -1,6 +1,6 @@
-import Browser from 'webextension-polyfill'
 import { type AWSCredentials } from '@/utilities'
 import { saveCredentials } from '@/utilities/storage'
+import Browser from 'webextension-polyfill'
 
 describe('Utilities', (): void => {
   const mockSet = Browser.storage.local.set as jest.MockedFunction<

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "2.4.0",
+        "@ianvs/prettier-plugin-sort-imports": "4.7.1",
         "@types/jest": "30.0.0",
         "@types/node": "24.12.2",
         "@types/react": "19.2.14",
@@ -24,6 +25,7 @@
         "@types/webextension-polyfill": "0.12.5",
         "@typescript-eslint/eslint-plugin": "8.58.1",
         "@typescript-eslint/parser": "8.58.1",
+        "@unfunco/prettier-plugin-yaml": "0.2.0",
         "@vitejs/plugin-react-swc": "4.3.0",
         "eslint": "10.2.0",
         "eslint-config-prettier": "10.1.8",
@@ -1582,6 +1584,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.7.1.tgz",
+      "integrity": "sha512-jmTNYGlg95tlsoG3JLCcuC4BrFELJtLirLAkQW/71lXSyOhVt/Xj7xWbbGcuVbNq1gwWgSyMrPjJc9Z30hynVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.2",
+        "@babel/parser": "^7.26.2",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "semver": "^7.5.2"
+      },
+      "peerDependencies": {
+        "@prettier/plugin-oxc": "^0.0.4 || ^0.1.0",
+        "@vue/compiler-sfc": "2.7.x || 3.x",
+        "content-tag": "^4.0.0",
+        "prettier": "2 || 3 || ^4.0.0-0",
+        "prettier-plugin-ember-template-tag": "^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "content-tag": {
+          "optional": true
+        },
+        "prettier-plugin-ember-template-tag": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3762,6 +3812,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unfunco/prettier-plugin-yaml": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@unfunco/prettier-plugin-yaml/-/prettier-plugin-yaml-0.2.0.tgz",
+      "integrity": "sha512-AUjSk9A4i28+OyFRVPr1Flaj7TLvX1HaTpG19TjCOsOQzNo6Dr5EOTzUvyMObEz16kRl8wWNqQZVudtvl6i8bg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "description": "Captures AWS SAML sign-ins and turns them into temporary STS credentials for the AWS CLI and SDKs.",
   "devDependencies": {
     "@crxjs/vite-plugin": "2.4.0",
+    "@ianvs/prettier-plugin-sort-imports": "4.7.1",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
     "@types/react": "19.2.14",
@@ -24,6 +25,7 @@
     "@types/webextension-polyfill": "0.12.5",
     "@typescript-eslint/eslint-plugin": "8.58.1",
     "@typescript-eslint/parser": "8.58.1",
+    "@unfunco/prettier-plugin-yaml": "0.2.0",
     "@vitejs/plugin-react-swc": "4.3.0",
     "eslint": "10.2.0",
     "eslint-config-prettier": "10.1.8",

--- a/src/bg/event.ts
+++ b/src/bg/event.ts
@@ -1,13 +1,13 @@
-import type { WebRequest } from 'webextension-polyfill'
-import { assumeRoleWithSAML } from '@/bg/sts'
 import {
   decodeSAMLAssertion,
   extractRoleArns,
   parseSAMLAssertion,
   selectRole,
 } from '@/bg/saml'
+import { assumeRoleWithSAML } from '@/bg/sts'
 import { summarizeCredentials } from '@/utilities/debug'
 import { saveCredentials } from '@/utilities/storage'
+import type { WebRequest } from 'webextension-polyfill'
 
 type RequestFormData = Record<string, string | string[] | undefined>
 const LOG_PREFIX = '[AWS SAML to STS][webRequest]'

--- a/src/bg/gc.ts
+++ b/src/bg/gc.ts
@@ -1,9 +1,9 @@
-import Browser from 'webextension-polyfill'
 import {
   summarizeCredentials,
   summarizeCredentialValue,
 } from '@/utilities/debug'
 import { isAWSCredentials } from '@/utilities/snippets'
+import Browser from 'webextension-polyfill'
 
 const CREDENTIALS_STORAGE_KEY = 'credentials'
 export const DEFAULT_GC_INTERVAL = 30_000

--- a/src/bg/index.ts
+++ b/src/bg/index.ts
@@ -1,6 +1,6 @@
-import Browser from 'webextension-polyfill'
 import { onBeforeRequestEvent } from '@/bg/event'
 import { startCredentialGarbageCollector } from '@/bg/gc'
+import Browser from 'webextension-polyfill'
 
 const AWS_SIGNIN_URL_SAML = 'https://signin.aws.amazon.com/saml'
 const LOG_PREFIX = '[AWS SAML to STS][background]'

--- a/src/bg/sts.ts
+++ b/src/bg/sts.ts
@@ -1,6 +1,6 @@
-import { STS, type AssumeRoleWithSAMLCommandOutput } from '@aws-sdk/client-sts'
 import { summarizeCredentials } from '@/utilities/debug'
 import type { AWSCredentials } from '@/utilities/snippets'
+import { STS, type AssumeRoleWithSAMLCommandOutput } from '@aws-sdk/client-sts'
 
 export type AssumeRoleWithSAMLRequest = {
   principalArn: string

--- a/src/components/Expiry.tsx
+++ b/src/components/Expiry.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { getRelativeTime } from '@/utilities'
+import React from 'react'
 
 type ExpiryProps = {
   /**

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,18 +1,18 @@
-import React, { useEffect, useState } from 'react'
 import CodeSnippet from '@/components/CodeSnippet'
+import Expiry from '@/components/Expiry'
+import GitHubIcon from '@/components/GitHubIcon'
 import {
-  type AWSCredentials,
   defaultCredentials,
   iniSnippet,
   isAWSCredentials,
   powershellSnippet,
   unixSnippet,
   windowsSnippet,
+  type AWSCredentials,
 } from '@/utilities'
 import { summarizeCredentialValue } from '@/utilities/debug'
+import React, { useEffect, useState } from 'react'
 import Browser, { type Storage } from 'webextension-polyfill'
-import Expiry from '@/components/Expiry'
-import GitHubIcon from '@/components/GitHubIcon'
 
 const PLATFORM_OPTIONS = [
   {

--- a/src/utilities/aws-sdk-xml-builder.ts
+++ b/src/utilities/aws-sdk-xml-builder.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from 'fast-xml-parser'
+
 export { XmlNode } from '@aws-sdk/xml-builder/dist-es/XmlNode.js'
 export { XmlText } from '@aws-sdk/xml-builder/dist-es/XmlText.js'
 

--- a/src/utilities/debug.ts
+++ b/src/utilities/debug.ts
@@ -1,4 +1,4 @@
-import { type AWSCredentials, isAWSCredentials } from '@/utilities/snippets'
+import { isAWSCredentials, type AWSCredentials } from '@/utilities/snippets'
 
 const formatTimestamp = (value: number): string => new Date(value).toISOString()
 

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -1,5 +1,5 @@
-import { type AWSCredentials } from '@/utilities/snippets'
 import { summarizeCredentials } from '@/utilities/debug'
+import { type AWSCredentials } from '@/utilities/snippets'
 import Browser from 'webextension-polyfill'
 
 const LOG_PREFIX = '[AWS SAML to STS][storage]'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
 import { crx, ManifestV3Export } from '@crxjs/vite-plugin'
+import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite'
 import manifest from './src/manifest'
 
 const SRC = resolve(__dirname, 'src')


### PR DESCRIPTION
This adds the prettier-plugin-yaml package to package.json and removes the *.yaml line from .prettierignore, as well as a plugin to ensure consistent import ordering in TypeScript files, the formatter has been ran with the new plugin rules in place.