### PR TITLE
chore: Bump @unfunco/prettier-plugin-yaml from 0.2.0 to 0.3.1

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -18,6 +18,7 @@
   "tabWidth": 2,
   "trailingComma": "all",
   "useTabs": false,
-  "yamlFlowCollectionSpacing": true,
-  "yamlIndentSequenceValues": false
+  "yamlIndentSequenceValue": false,
+  "yamlSpacesWithinBraces": true,
+  "yamlSpacesWithinBrackets": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/webextension-polyfill": "0.12.5",
         "@typescript-eslint/eslint-plugin": "8.58.1",
         "@typescript-eslint/parser": "8.58.1",
-        "@unfunco/prettier-plugin-yaml": "0.2.0",
+        "@unfunco/prettier-plugin-yaml": "0.3.1",
         "@vitejs/plugin-react-swc": "4.3.0",
         "eslint": "10.2.0",
         "eslint-config-prettier": "10.1.8",
@@ -3815,9 +3815,9 @@
       }
     },
     "node_modules/@unfunco/prettier-plugin-yaml": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@unfunco/prettier-plugin-yaml/-/prettier-plugin-yaml-0.2.0.tgz",
-      "integrity": "sha512-AUjSk9A4i28+OyFRVPr1Flaj7TLvX1HaTpG19TjCOsOQzNo6Dr5EOTzUvyMObEz16kRl8wWNqQZVudtvl6i8bg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@unfunco/prettier-plugin-yaml/-/prettier-plugin-yaml-0.3.1.tgz",
+      "integrity": "sha512-Ng+R2w/KVQxLPb9pQvxA2QSxkCB/BUEDBA9xMGqQXv3oagUJG9q0pp2o9RZz5fOsydoOkBn8swHU2P02+nD+ig==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/webextension-polyfill": "0.12.5",
     "@typescript-eslint/eslint-plugin": "8.58.1",
     "@typescript-eslint/parser": "8.58.1",
-    "@unfunco/prettier-plugin-yaml": "0.2.0",
+    "@unfunco/prettier-plugin-yaml": "0.3.1",
     "@vitejs/plugin-react-swc": "4.3.0",
     "eslint": "10.2.0",
     "eslint-config-prettier": "10.1.8",


### PR DESCRIPTION
## Summary
- bump @unfunco/prettier-plugin-yaml to v0.3.1
- replace deprecated yamlFlowCollectionSpacing with yamlSpacesWithinBraces and yamlSpacesWithinBrackets
- rename yamlIndentSequenceValues to yamlIndentSequenceValue to match the current plugin option name
