### PR TITLE
chore: bump prettier-plugin-yaml to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/webextension-polyfill": "0.12.5",
         "@typescript-eslint/eslint-plugin": "8.62.0",
         "@typescript-eslint/parser": "8.62.0",
-        "@unfunco/prettier-plugin-yaml": "0.3.1",
+        "@unfunco/prettier-plugin-yaml": "0.4.0",
         "@vitejs/plugin-react-swc": "4.3.1",
         "eslint": "10.6.0",
         "eslint-config-prettier": "10.1.8",
@@ -3098,9 +3098,9 @@
       }
     },
     "node_modules/@unfunco/prettier-plugin-yaml": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@unfunco/prettier-plugin-yaml/-/prettier-plugin-yaml-0.3.1.tgz",
-      "integrity": "sha512-Ng+R2w/KVQxLPb9pQvxA2QSxkCB/BUEDBA9xMGqQXv3oagUJG9q0pp2o9RZz5fOsydoOkBn8swHU2P02+nD+ig==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@unfunco/prettier-plugin-yaml/-/prettier-plugin-yaml-0.4.0.tgz",
+      "integrity": "sha512-3pfn44JZZv5jEj/3Fkn7Qk2AkGoK5SmLmCAi0C+uw2dYLcW0KD3wWY5WJfgLAUa7bFMiVlof3ysWWscmSxEAFA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/webextension-polyfill": "0.12.5",
     "@typescript-eslint/eslint-plugin": "8.62.0",
     "@typescript-eslint/parser": "8.62.0",
-    "@unfunco/prettier-plugin-yaml": "0.3.1",
+    "@unfunco/prettier-plugin-yaml": "0.4.0",
     "@vitejs/plugin-react-swc": "4.3.1",
     "eslint": "10.6.0",
     "eslint-config-prettier": "10.1.8",


### PR DESCRIPTION
## Summary

- upgrade `@unfunco/prettier-plugin-yaml` from 0.3.1 to 0.4.0
- refresh the npm lockfile without changing formatter configuration

## Checks

- `npm run fmt:check`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`